### PR TITLE
speeding up updating of all players

### DIFF
--- a/GUI.py
+++ b/GUI.py
@@ -322,9 +322,10 @@ class MyWindow(QMainWindow):
         temp_update_string = return_string + f"Updating Points for {player_to_update}"
         self.text_output_label.setText(temp_update_string)
 
-        return_string = logic.update_single_player_points_for_week(player_to_update, week_date_to_update,
-                                                                   week_index, league_to_update,
-                                                                   [self.lec_players, self.lcs_players], is_team)
+        return_string, players_list = logic.update_single_player_points_for_week(player_to_update, week_date_to_update,
+                                                                                 week_index, league_to_update,
+                                                                                 [self.lec_players, self.lcs_players],
+                                                                                 is_team)
         self.text_output_label.setText(return_string)
 
     def player_league_combobox_changed_action_thread(self, index):

--- a/GUI.py
+++ b/GUI.py
@@ -238,6 +238,9 @@ class MyWindow(QMainWindow):
         week_index = self.weeks.index(sel_week)
         week_date_to_update = self.matchup_dates[week_index]
 
+        temp_players_list = None
+        update_player_list = False
+
         for player in target_player_list:
             temp_update_string = return_string + f"Updating Points for {player}..."
             self.text_output_label.setText(temp_update_string)
@@ -252,10 +255,20 @@ class MyWindow(QMainWindow):
                 return_string = "Wrong league selected."
                 break
 
-            temp_return_string: str = logic.update_single_player_points_for_week(player_to_update, week_date_to_update,
-                                                                                 week_index, league_to_update,
-                                                                                 [self.lec_players, self.lcs_players],
-                                                                                 is_team)
+            if target_player_list[-1] == player:
+                update_player_list = True
+
+            dummy_return = logic.update_single_player_points_for_week(player_to_update,
+                                                                      week_date_to_update,
+                                                                      week_index,
+                                                                      league_to_update,
+                                                                      [self.lec_players,
+                                                                       self.lcs_players],
+                                                                      is_team,
+                                                                      temp_players_list,
+                                                                      update_player_list)
+            temp_players_list = dummy_return[1]
+            temp_return_string = dummy_return[0]
             if not temp_return_string.startswith('No New Games Found for'):
                 return_string += temp_return_string
                 return_string += "\n"

--- a/GUI.py
+++ b/GUI.py
@@ -269,7 +269,7 @@ class MyWindow(QMainWindow):
                                                                       update_player_list)
             temp_players_list = dummy_return[1]
             temp_return_string = dummy_return[0]
-            if not temp_return_string.startswith('No New Games Found for'):
+            if not temp_return_string.startswith('N'):
                 return_string += temp_return_string
                 return_string += "\n"
             self.text_output_label.setText(return_string)

--- a/Logic.py
+++ b/Logic.py
@@ -210,13 +210,13 @@ def update_single_player_points_for_week(player_string: str, date_string: str, w
                             )
 
     if response is None:
-        return f"Wrong api-request."
+        return [f"Wrong api-request.", players_list]
 
     player_data = response.get('cargoquery')
 
     spread_string_builder_lec = ['65', '124']
     spread_string_builder_lcs = ['81', '156']
-    spread_string_builder = ['F', 'G', 'H', 'I', 'J']
+    spread_string_builder = ['F', 'G', 'H', 'I', 'J', 'K', 'L', 'M', 'N', 'O']
 
     spread_string_index = spread_string_builder[week_index]
     spread_string_lec = f"D{spread_string_builder_lec[0]}:{spread_string_index}{spread_string_builder_lec[1]}"
@@ -227,8 +227,8 @@ def update_single_player_points_for_week(player_string: str, date_string: str, w
     temp_sum = 0
     games_played_so_far = len(player_data)
     if len(player_data) == 0:
-        games_played_so_far = 1
-        return f"No New Games Found for {player_string}"
+        return_string = f"No New Games Found for {player_string}"
+        return return_string, players_list
 
     lec_players, lcs_players = spreadsheets
     if players_list is None and league == "lec":
@@ -285,10 +285,11 @@ def update_single_player_points_for_week(player_string: str, date_string: str, w
     else:
         return_string = f"No New Games Found for {player_string}"
     print(return_string)
-    spread_string_update = spread_string.replace('D', spread_string_index)
     if update_player_list and league == 'lec':
+        spread_string_update = spread_string_lec.replace('D', spread_string_index)
         lec_players.update(spread_string_update, score_list_to_update)
     elif update_player_list and league == 'lcs':
+        spread_string_update = spread_string_lcs.replace('D', spread_string_index)
         lcs_players.update(spread_string_update, score_list_to_update)
     # return return_string
     return [return_string, players_list]

--- a/Logic.py
+++ b/Logic.py
@@ -166,7 +166,8 @@ def get_game_stats_and_update_spread(date_string: str, week_index: int, tourname
 
 
 def update_single_player_points_for_week(player_string: str, date_string: str, week_index: int,
-                                         league: str, spreadsheets: [], is_team: bool = False):
+                                         league: str, spreadsheets: [], is_team: bool = False, players_list=None,
+                                         update_player_list: bool = False):
     hour_string = "00:00:00"
     date_arr = [date_string, hour_string]
     date_time_string = ' '.join(date_arr)
@@ -223,7 +224,6 @@ def update_single_player_points_for_week(player_string: str, date_string: str, w
 
     spread_string = ""
     spread_string_update = ""
-    players_list = []
     temp_sum = 0
     games_played_so_far = len(player_data)
     if len(player_data) == 0:
@@ -231,14 +231,14 @@ def update_single_player_points_for_week(player_string: str, date_string: str, w
         return f"No New Games Found for {player_string}"
 
     lec_players, lcs_players = spreadsheets
-    if league == "lec":
+    if players_list is None and league == "lec":
         lec_players: worksheet = lec_players
         spread_string = spread_string_lec
         players_list = lec_players.get(spread_string)
-    elif league == "lcs":
+    elif players_list is None and league == "lcs":
         spread_string = spread_string_lcs
         players_list = lcs_players.get(spread_string)
-    else:
+    elif players_list is None:
         return f"wrong league String provided: {league}. \nAccepted strings are 'lec' and 'lcs'."
 
     for game_dict_key in player_data:
@@ -267,7 +267,10 @@ def update_single_player_points_for_week(player_string: str, date_string: str, w
                 player[-1] = temp_sum
                 score_list_to_update.append([temp_sum])
         else:
-            score_list_to_update.append([float(player[-1].replace(',', '.'))])
+            if type(player[-1]) is str:
+                score_list_to_update.append([float(player[-1].replace(',', '.'))])
+            elif type(player[-1]) is float:
+                score_list_to_update.append([player[-1]])
         if type(player[-1]) == str:
             player[-1] = float(player[-1].replace(',', '.'))
 
@@ -283,11 +286,12 @@ def update_single_player_points_for_week(player_string: str, date_string: str, w
         return_string = f"No New Games Found for {player_string}"
     print(return_string)
     spread_string_update = spread_string.replace('D', spread_string_index)
-    if league == 'lec':
+    if update_player_list and league == 'lec':
         lec_players.update(spread_string_update, score_list_to_update)
-    elif league == 'lcs':
+    elif update_player_list and league == 'lcs':
         lcs_players.update(spread_string_update, score_list_to_update)
-    return return_string
+    # return return_string
+    return [return_string, players_list]
 
 
 def calc_points(game_dictionary, category='player', team=None):


### PR DESCRIPTION
Implemented by delaying updating in the spreadsheet until all players have been updated and and keeping the current playerpoint list in memory

62 sec before update
27 sec after update

when using week 1 with LEC Teams and Players and updating all players and teams

currently crashing for weeks that are in the future